### PR TITLE
Refresh files when violation is ignored or removed from ignored list

### DIFF
--- a/src/main/java/com/code_inspector/plugins/intellij/annotators/CodeInspectorExternalAnnotator.java
+++ b/src/main/java/com/code_inspector/plugins/intellij/annotators/CodeInspectorExternalAnnotator.java
@@ -177,10 +177,10 @@ public class CodeInspectorExternalAnnotator extends ExternalAnnotator<PsiFile, L
                 annotationBuilder = annotationBuilder
                     .withFix(
                         new CodeInspectionAnnotationFixIgnore(
-                            projectId, Optional.of(annotation.getFilename()), annotation.getRule().get(), annotation.getLanguage().get(), annotation.getTool().get()))
+                            psiFile, projectId, Optional.of(annotation.getFilename()), annotation.getRule().get(), annotation.getLanguage().get(), annotation.getTool().get()))
                     .withFix(
                         new CodeInspectionAnnotationFixIgnore(
-                            projectId, Optional.empty(), annotation.getRule().get(), annotation.getLanguage().get(), annotation.getTool().get()));
+                            psiFile, projectId, Optional.empty(), annotation.getRule().get(), annotation.getLanguage().get(), annotation.getTool().get()));
             }
 
             /*

--- a/src/main/java/com/code_inspector/plugins/intellij/settings/project/IgnoredViolationsPanel.java
+++ b/src/main/java/com/code_inspector/plugins/intellij/settings/project/IgnoredViolationsPanel.java
@@ -3,9 +3,11 @@ package com.code_inspector.plugins.intellij.settings.project;
 import com.code_inspector.api.GetProjectsQuery;
 import com.code_inspector.plugins.intellij.cache.AnalysisDataCache;
 import com.code_inspector.plugins.intellij.graphql.CodeInspectorApi;
+import com.google.common.collect.ImmutableList;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.table.JBTable;
+import com.intellij.util.FileContentUtil;
 
 import javax.swing.*;
 import javax.swing.table.TableModel;
@@ -55,6 +57,9 @@ public class IgnoredViolationsPanel extends JPanel {
 
             // make sure we refresh our cache so that violations are coming back.
             AnalysisDataCache.getInstance().invalidateCache();
+
+            // re-parse files to surface issues that are now no longer being ignored.
+            FileContentUtil.reparseOpenedFiles();
         });
 
         JBScrollPane scrollPane = new JBScrollPane(table);


### PR DESCRIPTION
Used code from [this discussion](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360002671519-How-to-trigger-refresh-on-external-annotator) from the Jetbrains forum to implement file refresh when a violation is being ignored.