### PR TITLE
Map complex and long functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'com.apollographql.apollo:apollo-runtime:2.5.4'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testCompile 'org.mockito:mockito-core:3.8.0'
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/

--- a/src/main/java/com/code_inspector/plugins/intellij/annotators/CodeInspectionAnnotation.java
+++ b/src/main/java/com/code_inspector/plugins/intellij/annotators/CodeInspectionAnnotation.java
@@ -26,19 +26,19 @@ public class CodeInspectionAnnotation {
     private final @NotNull Optional<String> category;
     private final @NotNull TextRange range;
 
-    @NotNull CodeInspectionAnnotationKind getAnnotationKind() { return annotationKind; };
-    @NotNull Long getProjectId() { return projectId; }
-    @NotNull Long getAnalysisId() { return analysisId; }
-    @NotNull String getMessage() { return message; }
-    @NotNull Optional<String> getRule() { return rule; }
-    @NotNull Optional<String> getRuleUrl() { return ruleUrl; }
-    @NotNull String getFilename() { return filename; }
-    @NotNull Optional<String> getTool() { return tool; }
-    @NotNull Optional<String> getDescription() { return description; }
-    @NotNull Optional<LanguageEnumeration> getLanguage() { return language; }
-    @NotNull Optional<Long> getSeverity() { return severity; }
-    @NotNull Optional<String> getCategory() { return category; }
-    @NotNull TextRange range() { return range; }
+    @NotNull public CodeInspectionAnnotationKind getAnnotationKind() { return annotationKind; };
+    @NotNull public Long getProjectId() { return projectId; }
+    @NotNull public Long getAnalysisId() { return analysisId; }
+    @NotNull public String getMessage() { return message; }
+    @NotNull public Optional<String> getRule() { return rule; }
+    @NotNull public Optional<String> getRuleUrl() { return ruleUrl; }
+    @NotNull public String getFilename() { return filename; }
+    @NotNull public Optional<String> getTool() { return tool; }
+    @NotNull public Optional<String> getDescription() { return description; }
+    @NotNull public Optional<LanguageEnumeration> getLanguage() { return language; }
+    @NotNull public Optional<Long> getSeverity() { return severity; }
+    @NotNull public Optional<String> getCategory() { return category; }
+    @NotNull public TextRange range() { return range; }
 
     public CodeInspectionAnnotation(
         final @NotNull Long _projectId,

--- a/src/main/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiUtils.java
+++ b/src/main/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiUtils.java
@@ -141,13 +141,8 @@ public class CodeInspectorApiUtils {
 
         TextRange range = new TextRange(lineOffset.get().codeStartOffset, lineOffset.get().endOffset);
         return Optional.of(
-            new CodeInspectionAnnotation(
-                projectId,
-                analysisId,
-                CodeInspectionAnnotationKind.ComplexFunction,
-                description,
-                complexFunction.filename(),
-                range));
+            new CodeInspectionAnnotation(projectId, analysisId, CodeInspectionAnnotationKind.ComplexFunction,
+                description, complexFunction.filename(), range));
     }
 
     /**
@@ -195,12 +190,8 @@ public class CodeInspectorApiUtils {
         TextRange range = new TextRange(lineOffset.get().codeStartOffset, lineOffset.get().endOffset);
         return Optional.of(
             new CodeInspectionAnnotation(
-                projectId,
-                analysisId,
-                CodeInspectionAnnotationKind.LongFunction,
-                description,
-                longFunction.filename(),
-                range));
+                projectId, analysisId, CodeInspectionAnnotationKind.LongFunction,
+                description, longFunction.filename(), range));
     }
 
 

--- a/src/test/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiUtilsTest.java
+++ b/src/test/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiUtilsTest.java
@@ -34,8 +34,8 @@ public class CodeInspectorApiUtilsTest extends TestBase {
         GetFileDataQuery.LongFunction longFunction = mock(GetFileDataQuery.LongFunction.class);
         FileOffset fileOffset = mock(FileOffset.class);
         when(fileOffset.getLineOffsetAtLine(anyInt())).thenReturn(Optional.empty());
-        when(longFunction.lineStart()).thenReturn(new BigDecimal(1.0));
-        when(longFunction.length()).thenReturn(new BigDecimal(40));
+        when(longFunction.lineStart()).thenReturn(new BigDecimal("1.0"));
+        when(longFunction.length()).thenReturn(new BigDecimal("40"));
 
         Optional<CodeInspectionAnnotation> annotation = mapLongFunction(1L, 42L, longFunction, fileOffset, ImmutableMap.of());
         assertTrue(!annotation.isPresent());
@@ -50,8 +50,8 @@ public class CodeInspectorApiUtilsTest extends TestBase {
         LineOffset lineOffset = new LineOffset(42, 51, 45);
 
         when(fileOffset.getLineOffsetAtLine(anyInt())).thenReturn(Optional.of(lineOffset));
-        when(longFunction.lineStart()).thenReturn(new BigDecimal(1.0));
-        when(longFunction.length()).thenReturn(new BigDecimal(40));
+        when(longFunction.lineStart()).thenReturn(new BigDecimal("1.0"));
+        when(longFunction.length()).thenReturn(new BigDecimal("40"));
         when(longFunction.filename()).thenReturn("foobar.txt");
         when(longFunction.functionName()).thenReturn("superfunction");
 
@@ -77,8 +77,8 @@ public class CodeInspectorApiUtilsTest extends TestBase {
         GetFileDataQuery.ComplexFunction complexFunction = mock(GetFileDataQuery.ComplexFunction.class);
         FileOffset fileOffset = mock(FileOffset.class);
         when(fileOffset.getLineOffsetAtLine(anyInt())).thenReturn(Optional.empty());
-        when(complexFunction.lineStart()).thenReturn(new BigDecimal(1.0));
-        when(complexFunction.complexity()).thenReturn(new BigDecimal(51));
+        when(complexFunction.lineStart()).thenReturn(new BigDecimal("1.0"));
+        when(complexFunction.complexity()).thenReturn(new BigDecimal("51"));
 
         Optional<CodeInspectionAnnotation> annotation = mapComplexFunction(1L, 42L, complexFunction, fileOffset, ImmutableMap.of());
         assertTrue(!annotation.isPresent());
@@ -94,8 +94,8 @@ public class CodeInspectorApiUtilsTest extends TestBase {
         LineOffset lineOffset = new LineOffset(42, 51, 45);
 
         when(fileOffset.getLineOffsetAtLine(anyInt())).thenReturn(Optional.of(lineOffset));
-        when(complexFunction.lineStart()).thenReturn(new BigDecimal(1.0));
-        when(complexFunction.complexity()).thenReturn(new BigDecimal(51));
+        when(complexFunction.lineStart()).thenReturn(new BigDecimal("1.0"));
+        when(complexFunction.complexity()).thenReturn(new BigDecimal("51"));
         when(complexFunction.filename()).thenReturn("foobar.txt");
         when(complexFunction.functionName()).thenReturn("superfunction");
 

--- a/src/test/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiUtilsTest.java
+++ b/src/test/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiUtilsTest.java
@@ -1,0 +1,117 @@
+package com.code_inspector.plugins.intellij.graphql;
+
+
+
+import com.code_inspector.api.GetFileDataQuery;
+import com.code_inspector.plugins.intellij.annotators.CodeInspectionAnnotation;
+import com.code_inspector.plugins.intellij.annotators.CodeInspectionAnnotationKind;
+import com.code_inspector.plugins.intellij.git.CodeInspectorGitUtilsTest;
+import com.code_inspector.plugins.intellij.model.FileOffset;
+import com.code_inspector.plugins.intellij.model.LineOffset;
+import com.code_inspector.plugins.intellij.testutils.TestBase;
+import com.google.common.collect.ImmutableMap;
+import com.intellij.openapi.util.TextRange;
+import org.junit.jupiter.api.Test;
+
+import static com.code_inspector.plugins.intellij.graphql.CodeInspectorApiUtils.mapComplexFunction;
+import static com.code_inspector.plugins.intellij.graphql.CodeInspectorApiUtils.mapLongFunction;
+import static org.mockito.Mockito.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+
+public class CodeInspectorApiUtilsTest extends TestBase {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(CodeInspectorGitUtilsTest.class);
+
+    @Test
+    public void testMapLongFunctionOffsetAbsent() {
+        LOGGER.info(showTestHeader("testMapLongFunctionOffsetAbsent"));
+        GetFileDataQuery.LongFunction longFunction = mock(GetFileDataQuery.LongFunction.class);
+        FileOffset fileOffset = mock(FileOffset.class);
+        when(fileOffset.getLineOffsetAtLine(anyInt())).thenReturn(Optional.empty());
+        when(longFunction.lineStart()).thenReturn(new BigDecimal(1.0));
+        when(longFunction.length()).thenReturn(new BigDecimal(40));
+
+        Optional<CodeInspectionAnnotation> annotation = mapLongFunction(1L, 42L, longFunction, fileOffset, ImmutableMap.of());
+        assertTrue(!annotation.isPresent());
+    }
+
+    @Test
+    public void testMapLongFunctionOffsetPresent() {
+        LOGGER.info(showTestHeader("testMapLongFunctionOffsetPresent"));
+        String expectedDescription = "Function superfunction is too long with a length of 40 lines. Consider refactoring the function into sub-functions.";
+        GetFileDataQuery.LongFunction longFunction = mock(GetFileDataQuery.LongFunction.class);
+        FileOffset fileOffset = mock(FileOffset.class);
+        LineOffset lineOffset = new LineOffset(42, 51, 45);
+
+        when(fileOffset.getLineOffsetAtLine(anyInt())).thenReturn(Optional.of(lineOffset));
+        when(longFunction.lineStart()).thenReturn(new BigDecimal(1.0));
+        when(longFunction.length()).thenReturn(new BigDecimal(40));
+        when(longFunction.filename()).thenReturn("foobar.txt");
+        when(longFunction.functionName()).thenReturn("superfunction");
+
+        Optional<CodeInspectionAnnotation> annotationOptional = mapLongFunction(1L, 42L, longFunction, fileOffset, ImmutableMap.of());
+        assertTrue(annotationOptional.isPresent());
+        CodeInspectionAnnotation annotation = annotationOptional.get();
+        assertEquals(1L, annotation.getProjectId().longValue());
+        assertEquals(42L, annotation.getAnalysisId().longValue());
+        assertEquals("foobar.txt", annotation.getFilename());
+        assertEquals(CodeInspectionAnnotationKind.LongFunction, annotation.getAnnotationKind());
+        assertEquals(new TextRange(45, 51), annotation.range());
+        assertEquals(Optional.empty(), annotation.getRule());
+        assertEquals(Optional.empty(), annotation.getRuleUrl());
+        assertEquals(Optional.empty(), annotation.getTool());
+        assertEquals(Optional.empty(), annotation.getSeverity());
+        assertEquals(Optional.empty(), annotation.getCategory());
+        assertEquals(expectedDescription, annotation.getMessage());
+    }
+
+    @Test
+    public void testMapComplexFunctionOffsetAbsent() {
+        LOGGER.info(showTestHeader("testMapComplexFunctionOffsetAbsent"));
+        GetFileDataQuery.ComplexFunction complexFunction = mock(GetFileDataQuery.ComplexFunction.class);
+        FileOffset fileOffset = mock(FileOffset.class);
+        when(fileOffset.getLineOffsetAtLine(anyInt())).thenReturn(Optional.empty());
+        when(complexFunction.lineStart()).thenReturn(new BigDecimal(1.0));
+        when(complexFunction.complexity()).thenReturn(new BigDecimal(51));
+
+        Optional<CodeInspectionAnnotation> annotation = mapComplexFunction(1L, 42L, complexFunction, fileOffset, ImmutableMap.of());
+        assertTrue(!annotation.isPresent());
+    }
+
+    @Test
+    public void testMapComplexFunctionOffsetPresent() {
+        LOGGER.info(showTestHeader("testMapComplexFunctionOffsetPresent"));
+        String expectedDescription = "Function superfunction is too complex with a cyclomatic complexity of 51. Consider reducing the complexity of the function" +
+            "by refactoring it or simplifying its logic.";
+        GetFileDataQuery.ComplexFunction complexFunction = mock(GetFileDataQuery.ComplexFunction.class);
+        FileOffset fileOffset = mock(FileOffset.class);
+        LineOffset lineOffset = new LineOffset(42, 51, 45);
+
+        when(fileOffset.getLineOffsetAtLine(anyInt())).thenReturn(Optional.of(lineOffset));
+        when(complexFunction.lineStart()).thenReturn(new BigDecimal(1.0));
+        when(complexFunction.complexity()).thenReturn(new BigDecimal(51));
+        when(complexFunction.filename()).thenReturn("foobar.txt");
+        when(complexFunction.functionName()).thenReturn("superfunction");
+
+        Optional<CodeInspectionAnnotation> annotationOptional = mapComplexFunction(1L, 42L, complexFunction, fileOffset, ImmutableMap.of());
+        assertTrue(annotationOptional.isPresent());
+        CodeInspectionAnnotation annotation = annotationOptional.get();
+        assertEquals(1L, annotation.getProjectId().longValue());
+        assertEquals(42L, annotation.getAnalysisId().longValue());
+        assertEquals("foobar.txt", annotation.getFilename());
+        assertEquals(CodeInspectionAnnotationKind.ComplexFunction, annotation.getAnnotationKind());
+        assertEquals(new TextRange(45, 51), annotation.range());
+        assertEquals(Optional.empty(), annotation.getRule());
+        assertEquals(Optional.empty(), annotation.getRuleUrl());
+        assertEquals(Optional.empty(), annotation.getTool());
+        assertEquals(Optional.empty(), annotation.getSeverity());
+        assertEquals(Optional.empty(), annotation.getCategory());
+        assertEquals(expectedDescription, annotation.getMessage());
+    }
+}


### PR DESCRIPTION
Add mockito as a dependency in order to mock objects for testing purposes
- Add functions to map ComplexFunction and LongFunction objects into `CodeInspectionAnnotation`
- Add tests for mapping functions - `mapLongFunction` and `mapComplexFunction`
- Surface complex and long function annotations in IntelliJ