### PR TITLE
Fix crash, use real-time feedback and bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,20 @@
 # Code Inspector IntelliJ PlugIn Changelog
 
 ## [Unreleased]
-## [1.0.3]
-## [1.0.2]
+
+## [1.0.4]
+
 ### Added
+
+- Correctly fixing the project identifier when analyzing a file (Fixes: #32)
+- Fixes crash when trying to check what project has been notified (Fixes: #31)
+- Use Real-Time Feedback to analyze all files, even when project exists
+- Add the AccessRecord call when creating a file analysis
+
+### Fixed
+
+- Fix exception when sending notification to project (Fixes: #31)
+- Updating dependencies
 
 
 ## [1.0.2]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.5.10"
+    id("org.jetbrains.kotlin.jvm") version "1.5.20"
     // GraphQL
-    id("com.apollographql.apollo") version "2.5.8"
+    id("com.apollographql.apollo") version "2.5.9"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     id("org.jetbrains.intellij") version "0.7.2"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
@@ -25,11 +25,11 @@ repositories {
     jcenter()
 }
 dependencies {
-    implementation("com.apollographql.apollo:apollo-runtime:2.5.8")
+    implementation("com.apollographql.apollo:apollo-runtime:2.5.9")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    testCompile("org.mockito:mockito-core:3.11.1")
+    testCompile("org.mockito:mockito-core:3.11.2")
 }
 
 // Configure gradle-intellij-plugin plugin.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup = com.code-inspector.plugins
 pluginName = code-inspector-intellij-plugin
-pluginVersion = 1.0.3
+pluginVersion = 1.0.4
 
 pluginSinceBuild = 203
 pluginUntilBuild = 211.*

--- a/src/main/graphql/com/code_inspector/api/CreateFileAnalysis.graphql
+++ b/src/main/graphql/com/code_inspector/api/CreateFileAnalysis.graphql
@@ -1,3 +1,4 @@
 mutation CreateFileAnalysis ($projectId: Long, $filename: String!, $code: String!, $language: LanguageEnumeration!) {
     createFileAnalysis(projectId: $projectId, code: $code, language: $language, filename: $filename)
+    recordAccess(accessType: IntelliJ, actionType: FileAnalysisRequest)
 }

--- a/src/main/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiImpl.java
+++ b/src/main/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiImpl.java
@@ -290,7 +290,7 @@ public final class CodeInspectorApiImpl implements CodeInspectorApi{
     public Optional<GetFileAnalysisQuery.GetFileAnalysis> getFileAnalysis(String filename, String code, LanguageEnumeration language, Optional<Long> projectId) throws GraphQlQueryException {
         ApiRequest<Object> apiRequestSendFileForAnalysis = new ApiRequest<Object>();
 
-        final Input<Object> inputProjectId = Input.absent();
+        final Input<Object> inputProjectId = projectId.<Input<Object>>map(Input::fromNullable).orElseGet(Input::absent);
 
         /**
          * Send the analysis query

--- a/src/main/java/com/code_inspector/plugins/intellij/ui/NotificationUtils.java
+++ b/src/main/java/com/code_inspector/plugins/intellij/ui/NotificationUtils.java
@@ -27,7 +27,7 @@ public final class NotificationUtils {
     /**
      * Record the error already sent to projects
      */
-    private static Set<Pair<Project, String>> NOTIFICATION_ERROR_ONCE_PER_PROJECT = new ConcurrentSkipListSet<>();
+    private static Set<Pair<String, String>> NOTIFICATION_ERROR_ONCE_PER_PROJECT = new ConcurrentSkipListSet<>();
 
     /**
      * Do not instantiate this class.
@@ -45,7 +45,7 @@ public final class NotificationUtils {
         LOGGER.debug(notificationGroupManager.toString());
         LOGGER.debug(notificationGroup.toString());
 
-        Pair<Project, String> key = Pair.of(project, message);
+        Pair<String, String> key = Pair.of(project.getName(), message);
 
         if(NOTIFICATION_ERROR_ONCE_PER_PROJECT.contains(key)) {
             LOGGER.debug(String.format("not showing notification %s again on project %s", message, project.getName()));


### PR DESCRIPTION
- No longer use a project to detect if notification was already sent (Closes: Investigate crash from client #31)
- Use real-time feedback pipeline and correctly passes project as argument (Closes: Passing project for real-time feedback #32)