### PR TITLE
Remove annotation with the same text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 ### Added
+- remove duplicated errors that have the same message
 
 ### Changed
 - migrate `org.jetbrains.intellij` to `1.1.2`

--- a/src/main/java/com/code_inspector/plugins/intellij/annotators/CodeInspectorExternalAnnotator.java
+++ b/src/main/java/com/code_inspector/plugins/intellij/annotators/CodeInspectorExternalAnnotator.java
@@ -62,9 +62,12 @@ public class CodeInspectorExternalAnnotator extends ExternalAnnotator<PsiFile, L
         return psiFile;
     }
 
-
-
-
+    /**
+     * Get annotations for a file
+     * @param psiFile - the file opened in IntelliJ
+     * @param projectId - the related projectId if selected in IntelliJ
+     * @return - the list of annotations to add.
+     */
     @Nullable
     private List<CodeInspectionAnnotation> getAnnotationFromFileAnalysis(PsiFile psiFile, Optional<Long> projectId) {
         final String filename = psiFile.getName();

--- a/src/main/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiUtils.java
+++ b/src/main/java/com/code_inspector/plugins/intellij/graphql/CodeInspectorApiUtils.java
@@ -42,7 +42,7 @@ import static com.code_inspector.plugins.intellij.git.CodeInspectorGitUtils.inde
  * Utility class to convert data from the GraphQL API into data we can use for annotating the
  * source code.
  */
-public class CodeInspectorApiUtils {
+public final class CodeInspectorApiUtils {
 
     public static final Logger LOGGER = Logger.getInstance(LOGGER_NAME);
 
@@ -326,11 +326,17 @@ public class CodeInspectorApiUtils {
                 .map(v -> mapViolationFromFileAnalysis(v, fileOffset, filename, projectId))
                 .collect(Collectors.toList());
 
-            return allAnnotations
+            List<CodeInspectionAnnotation> allAnnotationsWithoutEmpty = allAnnotations
                 .stream()
                 .filter(v -> v.isPresent())
                 .map(v -> v.get())
                 .collect(Collectors.toList());
+
+            /**
+             * Before returning the list of errors, make sure we filter
+             * the error with the exact same message on the same text range.
+             */
+            return CodeInspectionAnnotation.filterDuplicatesByFileNameLineAndDescription(allAnnotationsWithoutEmpty);
         } catch (IOException ioe){
             ioe.printStackTrace();
             LOGGER.debug("cannot read file");

--- a/src/test/java/com/code_inspector/plugins/intellij/annotators/CodeInspectionAnnotationTest.java
+++ b/src/test/java/com/code_inspector/plugins/intellij/annotators/CodeInspectionAnnotationTest.java
@@ -1,0 +1,81 @@
+package com.code_inspector.plugins.intellij.annotators;
+
+import com.code_inspector.api.GetFileAnalysisQuery;
+import com.code_inspector.api.GetFileDataQuery;
+import com.code_inspector.plugins.intellij.cache.AnalysisDataCache;
+import com.code_inspector.plugins.intellij.git.CodeInspectorGitUtilsTest;
+import com.code_inspector.plugins.intellij.graphql.GraphQlQueryException;
+import com.code_inspector.plugins.intellij.testutils.TestBase;
+import com.google.common.collect.ImmutableList;
+import com.intellij.openapi.util.TextRange;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class CodeInspectionAnnotationTest extends TestBase {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(CodeInspectorGitUtilsTest.class);
+
+    @Test
+    public void testFilterDuplicatesByFileNameLineAndDescription() throws GraphQlQueryException {
+        CodeInspectionAnnotation annotation1 = new CodeInspectionAnnotation(
+                Optional.empty(),
+                Optional.empty(),
+                CodeInspectionAnnotationKind.Violation,
+                "msg1",
+                "filename",
+                new TextRange(1,2)
+                );
+        CodeInspectionAnnotation annotation2 = new CodeInspectionAnnotation(
+                Optional.empty(),
+                Optional.empty(),
+                CodeInspectionAnnotationKind.Violation,
+                "msg1",
+                "filename",
+                new TextRange(1,2)
+        );
+        CodeInspectionAnnotation annotation3 = new CodeInspectionAnnotation(
+                Optional.empty(),
+                Optional.empty(),
+                CodeInspectionAnnotationKind.Violation,
+                "msg1",
+                "filename",
+                new TextRange(2,3)
+        );
+        CodeInspectionAnnotation annotation4 = new CodeInspectionAnnotation(
+                Optional.empty(),
+                Optional.empty(),
+                CodeInspectionAnnotationKind.Violation,
+                "msg2",
+                "filename",
+                new TextRange(1,2)
+        );
+        CodeInspectionAnnotation annotation5 = new CodeInspectionAnnotation(
+                Optional.empty(),
+                Optional.empty(),
+                CodeInspectionAnnotationKind.Violation,
+                "msg1",
+                "filename2",
+                new TextRange(1,2)
+        );
+        assertEquals(1,
+                CodeInspectionAnnotation.filterDuplicatesByFileNameLineAndDescription(
+                        ImmutableList.of(annotation1, annotation2)
+                ).size());
+        assertEquals(2,
+                CodeInspectionAnnotation.filterDuplicatesByFileNameLineAndDescription(
+                        ImmutableList.of(annotation1, annotation3)
+                ).size());
+        assertEquals(2,
+                CodeInspectionAnnotation.filterDuplicatesByFileNameLineAndDescription(
+                        ImmutableList.of(annotation1, annotation4)
+                ).size());
+        assertEquals(2,
+                CodeInspectionAnnotation.filterDuplicatesByFileNameLineAndDescription(
+                        ImmutableList.of(annotation1, annotation5)
+                ).size());
+    }
+
+}


### PR DESCRIPTION
Sometimes, we have two rules producing the same text. We want to remove that in order to make sure the user experience is better with only one warning with the same message.

In this change, we make sure we have only one report for the same message.

Adding test to check we are correctly doing the filtering.